### PR TITLE
Change recommended URL for use as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ support for git URLs. For example, you can add the following to your
 
 ```toml
 dependencies = [
-    "epac-flatbuffer-formats @ git+ssh://git@github.com/CentralLaserFacility/epac-flatbuffer-formats@v0.1.0",
+    "epac-flatbuffer-formats @ git+https://github.com/CentralLaserFacility/epac-flatbuffer-formats@v0.1.0",
 ]
 ```
-
-> **Note:** this still needs to be tested
 
 Each data format can be serialised and deserialised in a similar way. For
 example, for `f142` (for recording values from a single PV):

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ support for git URLs. For example, you can add the following to your
 
 ```toml
 dependencies = [
-    "epac-flatbuffer-formats @ git+https://github.com/CentralLaserFacility/epac-flatbuffer-formats@v0.1.0",
+    "epac-flatbuffer-formats @ git+https://github.com/CentralLaserFacility/epac-flatbuffer-formats@v0.1.1",
 ]
 ```
 


### PR DESCRIPTION
It's much better to use HTTPS than SSH for public repos, because there's no setup needed.