### PR TITLE
Reverse axis ordering

### DIFF
--- a/src/epac/flatbuffers/area_detector_ADAr.py
+++ b/src/epac/flatbuffers/area_detector_ADAr.py
@@ -73,6 +73,9 @@ def serialise_ADAr(
         data_type = type_map[data.dtype]
 
     # Build dims
+    # Here the shape is reversed to match AreaDetector, which lists
+    # dimensions with fastest varying index first - the opposite order
+    # to the one numpy uses
     dims_offset = builder.CreateNumpyVector(np.asarray(data.shape[::-1]))
 
     # Build data
@@ -143,6 +146,9 @@ ADArray_t = ADArray
 
 
 def get_payload_data(fb_arr) -> np.ndarray:
+    # The dimensions are reversed when converting from AreaDetector
+    # to numpy, as AreaDetector lists its dimensions in the opposite
+    # order to numpy.
     return get_data(fb_arr).reshape(fb_arr.DimensionsAsNumpy()[::-1])
 
 

--- a/src/epac/flatbuffers/area_detector_ADAr.py
+++ b/src/epac/flatbuffers/area_detector_ADAr.py
@@ -143,7 +143,7 @@ ADArray_t = ADArray
 
 
 def get_payload_data(fb_arr) -> np.ndarray:
-    return get_data(fb_arr).reshape(fb_arr.DimensionsAsNumpy(), order='F').T
+    return get_data(fb_arr).reshape(fb_arr.DimensionsAsNumpy(), order="F").T
 
 
 def get_data(fb_arr) -> np.ndarray:

--- a/src/epac/flatbuffers/area_detector_ADAr.py
+++ b/src/epac/flatbuffers/area_detector_ADAr.py
@@ -73,7 +73,7 @@ def serialise_ADAr(
         data_type = type_map[data.dtype]
 
     # Build dims
-    dims_offset = builder.CreateNumpyVector(np.asarray(data.shape))
+    dims_offset = builder.CreateNumpyVector(np.asarray(data.T.shape))
 
     # Build data
     data_offset = builder.CreateNumpyVector(data.flatten().view(np.uint8))
@@ -143,7 +143,7 @@ ADArray_t = ADArray
 
 
 def get_payload_data(fb_arr) -> np.ndarray:
-    return get_data(fb_arr).reshape(fb_arr.DimensionsAsNumpy())
+    return get_data(fb_arr).reshape(fb_arr.DimensionsAsNumpy(), order='F').T
 
 
 def get_data(fb_arr) -> np.ndarray:

--- a/src/epac/flatbuffers/area_detector_ADAr.py
+++ b/src/epac/flatbuffers/area_detector_ADAr.py
@@ -73,7 +73,7 @@ def serialise_ADAr(
         data_type = type_map[data.dtype]
 
     # Build dims
-    dims_offset = builder.CreateNumpyVector(np.asarray(data.T.shape))
+    dims_offset = builder.CreateNumpyVector(np.asarray(data.shape[::-1]))
 
     # Build data
     data_offset = builder.CreateNumpyVector(data.flatten().view(np.uint8))
@@ -143,7 +143,7 @@ ADArray_t = ADArray
 
 
 def get_payload_data(fb_arr) -> np.ndarray:
-    return get_data(fb_arr).reshape(fb_arr.DimensionsAsNumpy(), order="F").T
+    return get_data(fb_arr).reshape(fb_arr.DimensionsAsNumpy()[::-1])
 
 
 def get_data(fb_arr) -> np.ndarray:


### PR DESCRIPTION
ADPluginKafka stores images in usual memory order, but lists its dimensions in colexicographic order (ascending order of stride, i.e. `[W,H]` for mono and `[3,W,H]` for "normal" (pixel-interleaved) RGB images). This is the opposite of the order many things (numpy in particular) expect dimensions to be listed in. 

`epac-flatbuffer-formats` does not currently account for this, so while it _can_ serialise and deserialise its own messages successfully, either deserialising ADPluginKafka-serialised messages, or serialising messages with `epac-flatbuffer-formats` and sending them to the file writer will produce garbled results. 

This replicates the same treatment of axis ordering in the `epac-flatbuffer-formats` ser/des code.

p.s. An alternative to this solution would be to change the loop ordering in ADPluginKafka [here](https://github.com/CentralLaserFacility/ADPluginKafka/blob/master/ADPluginKafkaApp/src/NDArraySerializer.cpp#L42-L44), e.g. by changing the indexing to `pArray.dims[pArray.ndims - y - 1].size` so that the flatbuffers contain dimension sizes in C order (and remove the special handling from the file writer as well), but we might not want to change our data format like this at this point. 

p.p.s. Someone from ESS has attempted to fix this issue in [this commit](https://gitlab.esss.lu.se/epics-modules/ADPluginKafka/-/merge_requests/1/diffs?commit_id=4b606c2ed20dd717474002b7c94119e999452d85) to the slightly-more-recently-updated ESS gitlab repo. Their "fix" is to hard-code the dimension order as `[H,W]`, or `[H,W,C]` if the array is more than 2D. This solves the problem for `Mono` and `RGB1` `ColorMode`s, but is completely broken for RGB2 (which should be `[H,C,W]`), RGB3 (`[C,H,W]`) and any arrays with more than three dimensions (which will only have three dimensions recorded). For these reasons (as we've discussed in person) I think we should ignore it.