### PR TITLE
Update for NumPy version > 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "epac-flatbuffer-formats"
 dependencies = [
     "flatbuffers==23.5.26",
-    "numpy>=1.26.0",
+    "numpy~=2.0",
 ]
 dynamic = ["version"]
 

--- a/src/epac/flatbuffers/logdata_f142.py
+++ b/src/epac/flatbuffers/logdata_f142.py
@@ -452,9 +452,7 @@ def _serialise_value(
 ):
     # We can use a dictionary to map most numpy types to one of the types defined in the flatbuffer schema
     # but we have to handle strings separately as there are many subtypes
-    if np.issubdtype(value.dtype, np.unicode_) or np.issubdtype(
-        value.dtype, np.string_
-    ):
+    if np.issubdtype(value.dtype, np.str_) or np.issubdtype(value.dtype, np.bytes_):
         # Strings were handled here once, but they were removed from the schema definition
         # This is left to give a nice clean error
         # All other string support code has been removed


### PR DESCRIPTION
In NumPy versions above 2.0.0, np.unicode_ and np.string_ are replaced by np.str_ and np.bytes_
Replacing the same in the code for f142