### PR TITLE
fix numpy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "epac-flatbuffer-formats"
 dependencies = [
     "flatbuffers==23.5.26",
-    "numpy~=2.0",
+    "numpy==2.0",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "epac-flatbuffer-formats"
 dependencies = [
     "flatbuffers==23.5.26",
-    "numpy==2.0",
+    "numpy==2.1.3",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
NumPy version 2.2 (released 8th Dec 2024) sets the item method for ndarrays return type to strings, which does not align with our usage, we rectify that by fixing to version 2.1.3. 