### PR TITLE
Amittal94/ca_to_pva

### DIFF
--- a/src/epac/flatbuffers/ca_to_pva.py
+++ b/src/epac/flatbuffers/ca_to_pva.py
@@ -114,22 +114,41 @@ class CaToNtConverter:
             limitHigh=limit_high,
         )
 
-    @classmethod
-    def convert_scalar(cls, data: dt.CAScalarAny | dict) -> dt.NTScalarAny:
-        """Converts CAScalarAny or scalar ca dictionary to NTScalarAny."""
+    def convert_scalar(
+        self,
+        data: dt.CAScalarAny | dict,
+        include_alarm: bool = True,
+        include_timestamp: bool = True,
+        include_display: bool = True,
+        include_control: bool = True,
+    ) -> dt.NTScalarAny:
+        """Converts CAScalarAny or scalar ca dictionary to NTScalarAny with optional serialization control."""
         if isinstance(data, dict):
             data = dt.CAScalarAny(**data)
+
         return dt.NTScalarAny(
             value=data.value,
-            alarm=cls.create_alarm(severity=data.severity, ca_status=data.status),
-            timeStamp=cls.create_timestamp(timestamp=data.timestamp),
-            display=cls.create_display(
-                limit_low=data.lower_disp_limit,
-                limit_high=data.upper_disp_limit,
-                units=data.units,
-                precision=data.precision,
+            alarm=(
+                self.create_alarm(data.severity, data.status) if include_alarm else None
             ),
-            control=cls.create_control(
-                limit_low=data.lower_ctrl_limit, limit_high=data.upper_ctrl_limit
+            timeStamp=(
+                self.create_timestamp(data.timestamp) if include_timestamp else None
+            ),
+            display=(
+                self.create_display(
+                    limit_low=data.lower_disp_limit,
+                    limit_high=data.upper_disp_limit,
+                    units=data.units,
+                    precision=data.precision,
+                )
+                if include_display
+                else None
+            ),
+            control=(
+                self.create_control(
+                    limit_low=data.lower_ctrl_limit, limit_high=data.upper_ctrl_limit
+                )
+                if include_control
+                else None
             ),
         )

--- a/src/epac/flatbuffers/ca_to_pva.py
+++ b/src/epac/flatbuffers/ca_to_pva.py
@@ -1,11 +1,10 @@
-from enum import Enum
+from enum import IntEnum
 
 import epac.flatbuffers.data_types as dt
-from epac.flatbuffers.fbschemas.pva0.AlarmStatus import AlarmStatus
 
 
-class PyEpicsConverter:
-    class CAAlarmStatus(Enum):
+class CaToNtConverter:
+    class CaAlarmStatus(IntEnum):
         NO_ALARM = 0
         READ = 1
         WRITE = 2
@@ -30,60 +29,61 @@ class PyEpicsConverter:
         WRITE_ACCESS = 21
 
     ALARM_TYPE = {
-        CAAlarmStatus.NO_ALARM.value: AlarmStatus.NONE,
+        CaAlarmStatus.NO_ALARM: dt.AlarmStatus.NONE,
         **{
-            key: AlarmStatus.DEVICE
+            key: dt.AlarmStatus.DEVICE
             for key in [
-                CAAlarmStatus.READ.value,
-                CAAlarmStatus.WRITE.value,
-                CAAlarmStatus.HIHI.value,
-                CAAlarmStatus.HIGH.value,
-                CAAlarmStatus.LOLO.value,
-                CAAlarmStatus.LOW.value,
-                CAAlarmStatus.STATE.value,
-                CAAlarmStatus.COS.value,
-                CAAlarmStatus.HW_LIMIT.value,
+                CaAlarmStatus.READ,
+                CaAlarmStatus.WRITE,
+                CaAlarmStatus.HIHI,
+                CaAlarmStatus.HIGH,
+                CaAlarmStatus.LOLO,
+                CaAlarmStatus.LOW,
+                CaAlarmStatus.STATE,
+                CaAlarmStatus.COS,
+                CaAlarmStatus.HW_LIMIT,
             ]
         },
         **{
-            key: AlarmStatus.DRIVER
+            key: dt.AlarmStatus.DRIVER
             for key in [
-                CAAlarmStatus.COMM.value,
-                CAAlarmStatus.TIMEOUT.value,
-                CAAlarmStatus.UDF.value,
+                CaAlarmStatus.COMM,
+                CaAlarmStatus.TIMEOUT,
+                CaAlarmStatus.UDF,
             ]
         },
         **{
-            key: AlarmStatus.RECORD
+            key: dt.AlarmStatus.RECORD
             for key in [
-                CAAlarmStatus.CALC.value,
-                CAAlarmStatus.SCAN.value,
-                CAAlarmStatus.LINK.value,
-                CAAlarmStatus.SOFT.value,
-                CAAlarmStatus.BAD_SUB.value,
+                CaAlarmStatus.CALC,
+                CaAlarmStatus.SCAN,
+                CaAlarmStatus.LINK,
+                CaAlarmStatus.SOFT,
+                CaAlarmStatus.BAD_SUB,
             ]
         },
         **{
-            key: AlarmStatus.DB
+            key: dt.AlarmStatus.DB
             for key in [
-                CAAlarmStatus.DISABLE.value,
-                CAAlarmStatus.SIMM.value,
-                CAAlarmStatus.READ_ACCESS.value,
-                CAAlarmStatus.WRITE_ACCESS.value,
+                CaAlarmStatus.DISABLE,
+                CaAlarmStatus.SIMM,
+                CaAlarmStatus.READ_ACCESS,
+                CaAlarmStatus.WRITE_ACCESS,
             ]
         },
     }
 
-    UNDEFINED_ALARM = AlarmStatus.UNDEFINED  # UNDEFINED
+    UNDEFINED_ALARM = dt.AlarmStatus.UNDEFINED  # UNDEFINED
 
     @classmethod
-    def create_alarm(cls, severity: int, status: int) -> dt.AlarmT:
+    def create_alarm(cls, severity: int, ca_status: int) -> dt.AlarmT:
         """Creates and returns an AlarmT object."""
-        alarm_status = cls.ALARM_TYPE.get(status, cls.UNDEFINED_ALARM)
         try:
-            alarm_msg = cls.CAAlarmStatus(status).name
+            alarm_status = cls.ALARM_TYPE[cls.CaAlarmStatus(ca_status)]
+            alarm_msg = cls.CaAlarmStatus(ca_status).name
         except ValueError:
-            alarm_msg = ""
+            alarm_status = cls.UNDEFINED_ALARM
+            alarm_msg = "undefined alarm status"
         return dt.AlarmT(severity=severity, status=alarm_status, message=alarm_msg)
 
     @staticmethod
@@ -115,11 +115,13 @@ class PyEpicsConverter:
         )
 
     @classmethod
-    def cascalarany_to_ntscalarany(cls, data: dt.CAScalarAny) -> dt.NTScalarAny:
-        """Converts CAScalarAny to NTScalarAny."""
+    def convert_scalar(cls, data: dt.CAScalarAny | dict) -> dt.NTScalarAny:
+        """Converts CAScalarAny or scalar ca dictionary to NTScalarAny."""
+        if isinstance(data, dict):
+            data = dt.CAScalarAny(**data)
         return dt.NTScalarAny(
             value=data.value,
-            alarm=cls.create_alarm(severity=data.severity, status=data.status),
+            alarm=cls.create_alarm(severity=data.severity, ca_status=data.status),
             timeStamp=cls.create_timestamp(timestamp=data.timestamp),
             display=cls.create_display(
                 limit_low=data.lower_disp_limit,

--- a/src/epac/flatbuffers/ca_to_pva.py
+++ b/src/epac/flatbuffers/ca_to_pva.py
@@ -1,30 +1,133 @@
+from enum import Enum
+
 import epac.flatbuffers.data_types as dt
+from epac.flatbuffers.fbschemas.pva0.AlarmStatus import AlarmStatus
 
 
-def cascalarany_to_ntscalarany(data: dt.CAScalarAny) -> dt.NTScalarAny:
-    alarm = dt.AlarmT(severity=data.severity, status=data.status)
+class PyEpicsConverter:
+    class CAAlarmStatus(Enum):
+        NO_ALARM = 0
+        READ = 1
+        WRITE = 2
+        HIHI = 3
+        HIGH = 4
+        LOLO = 5
+        LOW = 6
+        STATE = 7
+        COS = 8
+        COMM = 9
+        TIMEOUT = 10
+        HW_LIMIT = 11
+        CALC = 12
+        SCAN = 13
+        LINK = 14
+        SOFT = 15
+        BAD_SUB = 16
+        UDF = 17
+        DISABLE = 18
+        SIMM = 19
+        READ_ACCESS = 20
+        WRITE_ACCESS = 21
 
-    timeStamp = dt.TimeT(
-        secondsPastEpoch=int(data.timestamp),
-        nanoseconds=int((data.timestamp - int(data.timestamp)) * 1e9),
-    )
+    ALARM_TYPE = {
+        CAAlarmStatus.NO_ALARM.value: AlarmStatus.NONE,
+        **{
+            key: AlarmStatus.DEVICE
+            for key in [
+                CAAlarmStatus.READ.value,
+                CAAlarmStatus.WRITE.value,
+                CAAlarmStatus.HIHI.value,
+                CAAlarmStatus.HIGH.value,
+                CAAlarmStatus.LOLO.value,
+                CAAlarmStatus.LOW.value,
+                CAAlarmStatus.STATE.value,
+                CAAlarmStatus.COS.value,
+                CAAlarmStatus.HW_LIMIT.value,
+            ]
+        },
+        **{
+            key: AlarmStatus.DRIVER
+            for key in [
+                CAAlarmStatus.COMM.value,
+                CAAlarmStatus.TIMEOUT.value,
+                CAAlarmStatus.UDF.value,
+            ]
+        },
+        **{
+            key: AlarmStatus.RECORD
+            for key in [
+                CAAlarmStatus.CALC.value,
+                CAAlarmStatus.SCAN.value,
+                CAAlarmStatus.LINK.value,
+                CAAlarmStatus.SOFT.value,
+                CAAlarmStatus.BAD_SUB.value,
+            ]
+        },
+        **{
+            key: AlarmStatus.DB
+            for key in [
+                CAAlarmStatus.DISABLE.value,
+                CAAlarmStatus.SIMM.value,
+                CAAlarmStatus.READ_ACCESS.value,
+                CAAlarmStatus.WRITE_ACCESS.value,
+            ]
+        },
+    }
 
-    display = dt.DisplayT(
-        limitLow=data.lower_disp_limit,
-        limitHigh=data.upper_disp_limit,
-        units=data.units,
-        precision=data.precision or dt.DisplayT().precision,
-    )
+    UNDEFINED_ALARM = AlarmStatus.UNDEFINED  # UNDEFINED
 
-    control = dt.ControlT(
-        limitLow=data.lower_ctrl_limit,
-        limitHigh=data.upper_ctrl_limit,
-    )
+    @classmethod
+    def create_alarm(cls, severity: int, status: int) -> dt.AlarmT:
+        """Creates and returns an AlarmT object."""
+        alarm_status = cls.ALARM_TYPE.get(status, cls.UNDEFINED_ALARM)
+        try:
+            alarm_msg = cls.CAAlarmStatus(status).name
+        except ValueError:
+            alarm_msg = ""
+        return dt.AlarmT(severity=severity, status=alarm_status, message=alarm_msg)
 
-    return dt.NTScalarAny(
-        value=data.value,
-        alarm=alarm,
-        timeStamp=timeStamp,
-        display=display,
-        control=control,
-    )
+    @staticmethod
+    def create_timestamp(timestamp: float) -> dt.TimeT:
+        """Creates and returns a TimeT object."""
+        return dt.TimeT(
+            secondsPastEpoch=int(timestamp),
+            nanoseconds=int((timestamp - int(timestamp)) * 1e9),
+        )
+
+    @staticmethod
+    def create_display(
+        limit_low: float, limit_high: float, units: str, precision: int
+    ) -> dt.DisplayT:
+        """Creates and returns a DisplayT object."""
+        return dt.DisplayT(
+            limitLow=limit_low,
+            limitHigh=limit_high,
+            units=units,
+            precision=precision,
+        )
+
+    @staticmethod
+    def create_control(limit_low: float, limit_high: float) -> dt.ControlT:
+        """Creates and returns a ControlT object."""
+        return dt.ControlT(
+            limitLow=limit_low,
+            limitHigh=limit_high,
+        )
+
+    @classmethod
+    def cascalarany_to_ntscalarany(cls, data: dt.CAScalarAny) -> dt.NTScalarAny:
+        """Converts CAScalarAny to NTScalarAny."""
+        return dt.NTScalarAny(
+            value=data.value,
+            alarm=cls.create_alarm(severity=data.severity, status=data.status),
+            timeStamp=cls.create_timestamp(timestamp=data.timestamp),
+            display=cls.create_display(
+                limit_low=data.lower_disp_limit,
+                limit_high=data.upper_disp_limit,
+                units=data.units,
+                precision=data.precision,
+            ),
+            control=cls.create_control(
+                limit_low=data.lower_ctrl_limit, limit_high=data.upper_ctrl_limit
+            ),
+        )

--- a/src/epac/flatbuffers/ca_to_pva.py
+++ b/src/epac/flatbuffers/ca_to_pva.py
@@ -117,6 +117,7 @@ class CaToNtConverter:
     def convert_scalar(
         self,
         data: dt.CAScalarAny | dict,
+        *,
         include_alarm: bool = True,
         include_timestamp: bool = True,
         include_display: bool = True,

--- a/src/epac/flatbuffers/data_types.py
+++ b/src/epac/flatbuffers/data_types.py
@@ -12,6 +12,11 @@ class EnumT(BaseModel):
     choices: list[str] = []
 
 
+def replace_none(default_value):
+    """Returns a validator that replaces None with a given default value."""
+    return BeforeValidator(lambda v: v if v is not None else default_value)
+
+
 def extract_enum(enum_value: Optional[Any], enum_name: str, enum_type) -> int:
     """Handles both EnumT-style input and direct integer values, ensuring validity against enum_type."""
 
@@ -139,9 +144,7 @@ class CAScalarAny(BaseModel):
     value: Any
     pvname: str = ""
     status: int = 0
-    precision: Optional[int] = (
-        0  # precision appears to be the only optional field in pyepics (form="ctrl")
-    )
+    precision: Annotated[int, replace_none(0)]
     units: str = ""
     severity: int = 0
     timestamp: float

--- a/src/epac/flatbuffers/data_types.py
+++ b/src/epac/flatbuffers/data_types.py
@@ -142,16 +142,16 @@ class NTTable(BaseModel):
 
 class CAScalarAny(BaseModel):
     value: Any
-    pvname: str = ""
-    status: int = 0
-    precision: Annotated[int, replace_none(0)]
-    units: str = ""
-    severity: int = 0
+    pvname: Annotated[str, replace_none("")] = ""
+    status: Annotated[int, replace_none(0)] = 0
+    precision: Annotated[int, replace_none(0)] = 0
+    units: Annotated[str, replace_none("")] = ""
+    severity: Annotated[int, replace_none(0)] = 0
     timestamp: float
-    upper_disp_limit: float = 0
-    lower_disp_limit: float = 0
-    upper_ctrl_limit: float = 0
-    lower_ctrl_limit: float = 0
+    upper_disp_limit: Annotated[float, replace_none(0.0)] = 0.0
+    lower_disp_limit: Annotated[float, replace_none(0.0)] = 0.0
+    upper_ctrl_limit: Annotated[float, replace_none(0.0)] = 0.0
+    lower_ctrl_limit: Annotated[float, replace_none(0.0)] = 0.0
 
 
 class PVData(BaseModel):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,64 @@
+import epac.flatbuffers.data_types as dt
+from epac.flatbuffers.ca_to_pva import CaToNtConverter
+
+
+class TestCaToNtConverter:
+    def test_convert_scalar(self):
+        test_data_dict = {
+            "value": [47, 104, 111, 109],
+            "severity": 2,  # MAJOR
+            "status": 3,  # HIHI
+            "timestamp": 1741081171.628057718,
+            "lower_disp_limit": 5.0,
+            "upper_disp_limit": 1.0,
+            "units": "u",
+            "precision": 2,
+            "lower_ctrl_limit": 5.0,
+            "upper_ctrl_limit": 1.0,
+        }
+
+        converter = CaToNtConverter()
+        result = converter.convert_scalar(test_data_dict)
+
+        # check correct data types are created with correct values
+        assert isinstance(result, dt.NTScalarAny)
+        assert result.value == [47, 104, 111, 109]
+        assert isinstance(result.alarm, dt.AlarmT)
+        assert result.alarm.status == dt.AlarmStatus.DEVICE
+        assert result.alarm.severity == dt.AlarmSeverity.MAJOR
+        assert result.alarm.message == CaToNtConverter.CaAlarmStatus.HIHI.name
+        assert isinstance(result.timeStamp, dt.TimeT)
+        assert result.timeStamp.secondsPastEpoch == int(test_data_dict["timestamp"])
+        assert result.timeStamp.nanoseconds == int(
+            (test_data_dict["timestamp"] - int(test_data_dict["timestamp"])) * 1e9
+        )
+        assert isinstance(result.display, dt.DisplayT)
+        assert result.display.limitLow == test_data_dict["lower_disp_limit"]
+        assert result.display.limitHigh == test_data_dict["upper_disp_limit"]
+        assert result.display.units == test_data_dict["units"]
+        assert result.display.precision == test_data_dict["precision"]
+        assert isinstance(result.control, dt.ControlT)
+        assert result.control.limitLow == test_data_dict["lower_ctrl_limit"]
+        assert result.control.limitHigh == test_data_dict["upper_ctrl_limit"]
+
+        # check result is the same if directly passed a ca scalar data type instead of a dictionary
+        test_data_ca_scalar = dt.CAScalarAny(**test_data_dict)
+        result_ca_scalar = converter.convert_scalar(test_data_ca_scalar)
+        assert result == result_ca_scalar
+
+    def test_missing_data_defaults(self):
+        test_data_dict = {
+            "value": [47, 104, 111, 109],
+            "timestamp": 1741081171.628057718,
+        }
+
+        test_data = dt.CAScalarAny(**test_data_dict)
+        assert test_data.pvname == ""
+        assert test_data.status == 0
+        assert test_data.precision == 0
+        assert test_data.units == ""
+        assert test_data.severity == 0
+        assert test_data.upper_disp_limit == 0.0
+        assert test_data.lower_disp_limit == 0.0
+        assert test_data.upper_ctrl_limit == 0.0
+        assert test_data.lower_ctrl_limit == 0.0

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,64 +1,133 @@
+import pytest
 import epac.flatbuffers.data_types as dt
 from epac.flatbuffers.ca_to_pva import CaToNtConverter
 
 
-class TestCaToNtConverter:
-    def test_convert_scalar(self):
-        test_data_dict = {
-            "value": [47, 104, 111, 109],
-            "severity": 2,  # MAJOR
-            "status": 3,  # HIHI
-            "timestamp": 1741081171.628057718,
-            "lower_disp_limit": 5.0,
-            "upper_disp_limit": 1.0,
-            "units": "u",
-            "precision": 2,
-            "lower_ctrl_limit": 5.0,
-            "upper_ctrl_limit": 1.0,
-        }
+@pytest.fixture
+def converter():
+    return CaToNtConverter()
 
-        converter = CaToNtConverter()
-        result = converter.convert_scalar(test_data_dict)
 
-        # check correct data types are created with correct values
-        assert isinstance(result, dt.NTScalarAny)
-        assert result.value == [47, 104, 111, 109]
-        assert isinstance(result.alarm, dt.AlarmT)
-        assert result.alarm.status == dt.AlarmStatus.DEVICE
-        assert result.alarm.severity == dt.AlarmSeverity.MAJOR
-        assert result.alarm.message == CaToNtConverter.CaAlarmStatus.HIHI.name
-        assert isinstance(result.timeStamp, dt.TimeT)
-        assert result.timeStamp.secondsPastEpoch == int(test_data_dict["timestamp"])
-        assert result.timeStamp.nanoseconds == int(
-            (test_data_dict["timestamp"] - int(test_data_dict["timestamp"])) * 1e9
-        )
-        assert isinstance(result.display, dt.DisplayT)
-        assert result.display.limitLow == test_data_dict["lower_disp_limit"]
-        assert result.display.limitHigh == test_data_dict["upper_disp_limit"]
-        assert result.display.units == test_data_dict["units"]
-        assert result.display.precision == test_data_dict["precision"]
-        assert isinstance(result.control, dt.ControlT)
-        assert result.control.limitLow == test_data_dict["lower_ctrl_limit"]
-        assert result.control.limitHigh == test_data_dict["upper_ctrl_limit"]
+@pytest.mark.parametrize(
+    "severity, ca_status, expected_status, expected_message",
+    [
+        (0, 0, dt.AlarmStatus.NONE, "NO_ALARM"),
+        (1, 3, dt.AlarmStatus.DEVICE, "HIHI"),
+        (2, 9, dt.AlarmStatus.DRIVER, "COMM"),
+        (3, 15, dt.AlarmStatus.RECORD, "SOFT"),
+        (0, 20, dt.AlarmStatus.DB, "READ_ACCESS"),
+        (1, 999, dt.AlarmStatus.UNDEFINED, "undefined alarm status"),  # Invalid status
+    ],
+)
+def test_create_alarm(
+    converter, severity, ca_status, expected_status, expected_message
+):
+    result = converter.create_alarm(severity, ca_status)
 
-        # check result is the same if directly passed a ca scalar data type instead of a dictionary
-        test_data_ca_scalar = dt.CAScalarAny(**test_data_dict)
-        result_ca_scalar = converter.convert_scalar(test_data_ca_scalar)
-        assert result == result_ca_scalar
+    assert isinstance(result, dt.AlarmT)
+    assert result.severity == severity
+    assert result.status == expected_status
+    assert result.message == expected_message
 
-    def test_missing_data_defaults(self):
-        test_data_dict = {
-            "value": [47, 104, 111, 109],
-            "timestamp": 1741081171.628057718,
-        }
 
-        test_data = dt.CAScalarAny(**test_data_dict)
-        assert test_data.pvname == ""
-        assert test_data.status == 0
-        assert test_data.precision == 0
-        assert test_data.units == ""
-        assert test_data.severity == 0
-        assert test_data.upper_disp_limit == 0.0
-        assert test_data.lower_disp_limit == 0.0
-        assert test_data.upper_ctrl_limit == 0.0
-        assert test_data.lower_ctrl_limit == 0.0
+@pytest.mark.parametrize(
+    "timestamp, expected_seconds, expected_nanoseconds",
+    [
+        (1741081171.628057718, 1741081171, 628057718),
+        (0.0, 0, 0),  # Unix epoch start
+    ],
+)
+def test_create_timestamp(converter, timestamp, expected_seconds, expected_nanoseconds):
+    result = converter.create_timestamp(timestamp)
+
+    assert isinstance(result, dt.TimeT)
+    assert result.secondsPastEpoch == expected_seconds
+    assert result.nanoseconds == expected_nanoseconds
+
+
+def test_create_display(converter):
+    result = converter.create_display(1.5, 10.5, "m", 2)
+
+    assert isinstance(result, dt.DisplayT)
+    assert result.limitLow == 1.5
+    assert result.limitHigh == 10.5
+    assert result.units == "m"
+    assert result.precision == 2
+
+
+def test_create_control(converter):
+    result = converter.create_control(-5.0, 5.0)
+
+    assert isinstance(result, dt.ControlT)
+    assert result.limitLow == -5.0
+    assert result.limitHigh == 5.0
+
+
+def test_convert_scalar(converter):
+    test_data_dict = {
+        "value": [47, 104, 111, 109],
+        "severity": 2,  # MAJOR
+        "status": 3,  # HIHI
+        "timestamp": 1741081171.628057718,
+        "lower_disp_limit": 5.0,
+        "upper_disp_limit": 1.0,
+        "units": "u",
+        "precision": 2,
+        "lower_ctrl_limit": 5.0,
+        "upper_ctrl_limit": 1.0,
+    }
+
+    result = converter.convert_scalar(test_data_dict)
+
+    # check correct data types are created with correct values
+    assert isinstance(result, dt.NTScalarAny)
+    assert result.value == [47, 104, 111, 109]
+
+    assert isinstance(result.alarm, dt.AlarmT)
+    assert result.alarm.status == dt.AlarmStatus.DEVICE
+    assert result.alarm.severity == dt.AlarmSeverity.MAJOR
+    assert result.alarm.message == CaToNtConverter.CaAlarmStatus.HIHI.name
+
+    assert isinstance(result.timeStamp, dt.TimeT)
+    assert result.timeStamp.secondsPastEpoch == int(test_data_dict["timestamp"])
+    assert result.timeStamp.nanoseconds == int(
+        (test_data_dict["timestamp"] - int(test_data_dict["timestamp"])) * 1e9
+    )
+    assert isinstance(result.display, dt.DisplayT)
+    assert result.display.limitLow == test_data_dict["lower_disp_limit"]
+    assert result.display.limitHigh == test_data_dict["upper_disp_limit"]
+    assert result.display.units == test_data_dict["units"]
+    assert result.display.precision == test_data_dict["precision"]
+    assert isinstance(result.control, dt.ControlT)
+
+    assert result.control.limitLow == test_data_dict["lower_ctrl_limit"]
+    assert result.control.limitHigh == test_data_dict["upper_ctrl_limit"]
+
+    # check result is the same if directly passed a ca scalar data type instead of a dictionary
+    test_data_ca_scalar = dt.CAScalarAny(**test_data_dict)
+    result_ca_scalar = converter.convert_scalar(test_data_ca_scalar)
+    assert result == result_ca_scalar
+
+
+def test_convert_scalar_missing_fields(converter):
+    test_data_dict = {
+        "value": [100],
+        "timestamp": 1000.5,
+    }
+
+    result = converter.convert_scalar(test_data_dict)
+
+    assert isinstance(result.alarm, dt.AlarmT)
+    assert result.alarm.status == dt.AlarmStatus.NONE
+    assert result.alarm.severity == 0
+    assert result.alarm.message == "NO_ALARM"
+
+    assert isinstance(result.display, dt.DisplayT)
+    assert result.display.limitLow == 0.0
+    assert result.display.limitHigh == 0.0
+    assert result.display.units == ""
+    assert result.display.precision == 0
+
+    assert isinstance(result.control, dt.ControlT)
+    assert result.control.limitLow == 0.0
+    assert result.control.limitHigh == 0.0


### PR DESCRIPTION
A more structured format for converting from pyepics result to pva data types. I also made a validator to set defaults instead of None but need to identify where to use it. I'm fairly sure in p4p unless the whole section i.e alarm is none, then the internal keys are always present. So currently, it should only be needed in ca stuff, that is to say, CAScalarAny, which might be the only use case.