### PR TITLE
change source_name to sourceName in data_types

### DIFF
--- a/src/epac/flatbuffers/data_types.py
+++ b/src/epac/flatbuffers/data_types.py
@@ -153,4 +153,4 @@ class CAScalarAny(BaseModel):
 
 class PVData(BaseModel):
     data: Union[NTScalarAny, NTNDArray, NTTable]
-    source_name: str = ""
+    sourceName: str = ""

--- a/src/epac/flatbuffers/pva0_data.py
+++ b/src/epac/flatbuffers/pva0_data.py
@@ -944,7 +944,7 @@ def serialise_data(data: dt.PVData) -> bytes:
     else:
         raise TypeError(f"unsupported data type: {type(data.data)}")
 
-    source_name_offset = builder.CreateString(data.source_name)
+    source_name_offset = builder.CreateString(data.sourceName)
 
     if data.data.value is None:
         raise ValueError("must have a value")
@@ -981,21 +981,21 @@ def deserialise_data(buffer: bytes) -> dt.PVData:
         ntscalarany_data.Init(data_buffer.Bytes, data_buffer.Pos)
         return dt.PVData(
             data=deserialise_ntscalarany(ntscalarany_data),
-            source_name=pv_data.SourceName().decode("utf-8"),
+            sourceName=pv_data.SourceName().decode("utf-8"),
         )
     elif data_type == PVType.PVType.NTNDArray:
         ntndarray_data = NTNDArray.NTNDArray()
         ntndarray_data.Init(data_buffer.Bytes, data_buffer.Pos)
         return dt.PVData(
             data=deserialise_ntndarray(ntndarray_data),
-            source_name=pv_data.SourceName().decode("utf-8"),
+            sourceName=pv_data.SourceName().decode("utf-8"),
         )
     elif data_type == PVType.PVType.NTTable:
         nttable_data = NTTable.NTTable()
         nttable_data.Init(data_buffer.Bytes, data_buffer.Pos)
         return dt.PVData(
             data=deserialise_nttable(nttable_data),
-            source_name=pv_data.SourceName().decode("utf-8"),
+            sourceName=pv_data.SourceName().decode("utf-8"),
         )
     else:
         raise ValueError(f"unsupported data type: {data_type}")


### PR DESCRIPTION
in data types all the pva data comes in camelCase, so it may be better to rename the source_name to sourceName in our defined pvdata for consistency. Debatably this might be possible in CAScalarAny as well, but pyepics sends snake_case variables.