### PR TITLE
Make NTAttribute.value optional

### DIFF
--- a/src/epac/flatbuffers/data_types.py
+++ b/src/epac/flatbuffers/data_types.py
@@ -105,7 +105,7 @@ class DimensionT(BaseModel):
 
 class NTAttribute(BaseModel):
     name: str = ""
-    value: RequiredAny
+    value: Any
     tags: list[str] = []
     descriptor: str = ""
     alarm: Optional[AlarmT] = None

--- a/tests/test_pva0.py
+++ b/tests/test_pva0.py
@@ -72,7 +72,17 @@ class TestSerialisationPVA0:
                     "alarm": None,
                     "time": None,
                     "tags": ["tag1", "tag2"],
-                }
+                },
+                {
+                    "name": "Empty",
+                    "value": None,
+                    "descriptor": "",
+                    "sourceType": 0,
+                    "source": "",
+                    "alarm": None,
+                    "time": None,
+                    "tags": [],
+                },
             ],
             "descriptor": "",
             "alarm": {"severity": 0, "status": 0, "message": "NO_ALARM"},

--- a/tests/test_pva0.py
+++ b/tests/test_pva0.py
@@ -188,10 +188,6 @@ class TestSerialisationPVA0:
             "value": None,
         }
 
-        nt_attribute_dict = {
-            "value": None,
-        }
-
         nt_column_dict = {
             "value": None,
         }
@@ -205,9 +201,6 @@ class TestSerialisationPVA0:
 
         with pytest.raises(ValueError):
             dt.NTNDArray(**nt_ndarray_dict)
-
-        with pytest.raises(ValueError):
-            dt.NTAttribute(**nt_attribute_dict)
 
         with pytest.raises(ValueError):
             dt.Column(**nt_column_dict)


### PR DESCRIPTION
The normative types spec says it's required, but I've seen it missing a value and the flatbuffers schema says it's optional.